### PR TITLE
Remove login and signup buttons for logged in users

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,12 +12,6 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
-          <li class="nav-item active">
-            <%= link_to "Login", ("#"), class: "nav-button" %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "Sign up", ("#"), class: "nav-button" %>
-          </li>
           <li class="nav-item dropdown">
             <a href="#" id="navbarDropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               <% if current_user.avatar.attached? %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -21,9 +21,9 @@
               <% end %>
             </a>
             <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-              <%= link_to "Action", "#", class: "dropdown-item" %>
-              <%= link_to "Another action", "#", class: "dropdown-item" %>
-              <%= button_to "Log Out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
+              <%= link_to "My profile", "#", class: "dropdown-item" %>
+              <%= link_to "My dashboard", dashboard_path, class: "dropdown-item" %>
+              <%= button_to "Log out", destroy_user_session_path, method: :delete, class: "dropdown-item" %>
             </div>
           </li>
         <% else %>


### PR DESCRIPTION
- From navbar, remove login and signup buttons for logged in users;
- Before login shows buttons 'login' and 'sign up', after login shows only avatar.